### PR TITLE
set up test infrastructure

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,7 +2,7 @@ require 'sinatra/base'
 
 class Battle < Sinatra::Base
   get '/' do
-    'Hello Battle! Heroku Test'
+    'Test Setup'
   end
 
   run! if app_file == $0

--- a/spec/features/testing_infrastructure_spec.rb
+++ b/spec/features/testing_infrastructure_spec.rb
@@ -1,0 +1,6 @@
+feature 'Testing infrastructure' do
+  scenario 'Can run app and check page content' do
+    visit('/')
+    expect(page).to have_content 'Test Setup'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,18 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
 ])
 SimpleCov.start
 
+ENV['RACK_ENV'] = 'test'
+
+# require our Sinatra app file
+require File.join(File.dirname(__FILE__), '..', 'app.rb')
+
+require 'capybara'
+require 'capybara/rspec'
+require 'rspec'
+
+# tell Capybara about our app class
+Capybara.app = Battle
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Set RACK_ENV to test.
Require Sinatra app file, capybara, capybara/rspec and rspec.
Tell Capybara about app class using Capybara.app.
Write a feature test that checks that the hompage says Test Setup.
Pass RSpec.